### PR TITLE
Add Supabase auth login and language route

### DIFF
--- a/filmclubapp/app/language/page.tsx
+++ b/filmclubapp/app/language/page.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+
+/**
+ * Language selection page.
+ * Allows users to choose between Hebrew and English after logging in.
+ */
+export default function LanguagePage() {
+  return (
+    <main className="max-w-3xl mx-auto p-6 flex flex-col gap-8 items-center">
+      <h1 className="text-3xl font-extrabold text-center">
+        בחרו שפה&nbsp;/&nbsp;Choose your language
+      </h1>
+      <div className="grid gap-4 sm:grid-cols-2 w-full max-w-md">
+        <Link
+          href="/he"
+          className="rounded-2xl shadow p-6 bg-white flex items-center justify-center text-xl font-bold hover:bg-gray-100"
+        >
+          עברית
+        </Link>
+        <Link
+          href="/en"
+          className="rounded-2xl shadow p-6 bg-white flex items-center justify-center text-xl font-bold hover:bg-gray-100"
+        >
+          English
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/filmclubapp/app/page.tsx
+++ b/filmclubapp/app/page.tsx
@@ -1,30 +1,73 @@
-import Link from 'next/link';
+'use client';
+import { useState, FormEvent } from 'react';
+import { supabase } from '@/lib/supabase';
+import { useRouter } from 'next/navigation';
 
 /**
- * Language selection page.
- * This page allows visitors to choose between Hebrew and English before entering the site.
- * Each option links to the appropriate language-specific landing page.
+ * Home page with login / sign-up form.
+ * After successful authentication user is redirected to /language.
  */
-export default function Page() {
+export default function HomePage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSignUp, setIsSignUp] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!email || !password) return;
+    let authError;
+    if (isSignUp) {
+      const { error } = await supabase.auth.signUp({ email, password });
+      authError = error;
+    } else {
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      authError = error;
+    }
+    if (authError) {
+      setError(authError.message);
+    } else {
+      router.push('/language');
+    }
+  }
+
   return (
-    <main className="max-w-3xl mx-auto p-6 flex flex-col gap-8 items-center">
-      <h1 className="text-3xl font-extrabold text-center">
-        בחרו שפה&nbsp;/&nbsp;Choose your language
-      </h1>
-      <div className="grid gap-4 sm:grid-cols-2 w-full max-w-md">
-        <Link
-          href="/he"
-          className="rounded-2xl shadow p-6 bg-white flex items-center justify-center text-xl font-bold hover:bg-gray-100"
-        >
-          עברית
-        </Link>
-        <Link
-          href="/en"
-          className="rounded-2xl shadow p-6 bg-white flex items-center justify-center text-xl font-bold hover:bg-gray-100"
-        >
-          English
-        </Link>
-      </div>
-    </main>
+    <div className="flex flex-col gap-4 max-w-sm mx-auto">
+      <h1 className="text-2xl font-bold">{isSignUp ? 'Sign Up' : 'Log In'}</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm">Email</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="border rounded px-3 py-2"
+            required
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm">Password</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="border rounded px-3 py-2"
+            required
+          />
+        </label>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button type="submit" className="px-4 py-2 rounded-xl bg-black text-white">
+          {isSignUp ? 'Sign Up' : 'Log In'}
+        </button>
+      </form>
+      <button
+        onClick={() => setIsSignUp((p) => !p)}
+        className="text-sm text-blue-600 underline"
+      >
+        {isSignUp ? 'Already have an account? Log in' : "Don't have an account? Sign up"}
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace root page with a Supabase-powered email/password login and sign-up form that redirects to `/language`
- Move former language selector into new `/language` route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next lint prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b20aa7d328832a9739eddd49775e56