### PR TITLE
Use env ADMIN_TOKEN and clarify token errors

### DIFF
--- a/filmclubapp/app/admin/page.tsx
+++ b/filmclubapp/app/admin/page.tsx
@@ -20,8 +20,13 @@ export default function AdminPage() {
   });
 
   useEffect(() => {
-    const stored = localStorage.getItem('admin_token');
-    if (stored) setToken(stored);
+    const envToken = process.env.NEXT_PUBLIC_ADMIN_TOKEN || process.env.ADMIN_TOKEN;
+    if (envToken) {
+      setToken(envToken);
+    } else {
+      const stored = localStorage.getItem('admin_token');
+      if (stored) setToken(stored);
+    }
   }, []);
 
   useEffect(() => {

--- a/filmclubapp/app/api/meetings/route.ts
+++ b/filmclubapp/app/api/meetings/route.ts
@@ -32,9 +32,15 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   const auth = request.headers.get('authorization') || request.headers.get('Authorization');
-  const adminToken = process.env.ADMIN_TOKEN;
-  if (!auth || !adminToken || auth !== `Bearer ${adminToken}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const adminToken = process.env.ADMIN_TOKEN || process.env.NEXT_PUBLIC_ADMIN_TOKEN;
+  if (!adminToken) {
+    return NextResponse.json({ error: 'Server misconfigured: ADMIN_TOKEN not set' }, { status: 500 });
+  }
+  if (!auth) {
+    return NextResponse.json({ error: 'Missing Authorization header' }, { status: 401 });
+  }
+  if (auth !== `Bearer ${adminToken}`) {
+    return NextResponse.json({ error: 'Invalid admin token' }, { status: 403 });
   }
   const body = await request.json();
   const { club_id, film_id, starts_at, capacity = 100, zoom_url, agenda } = body;


### PR DESCRIPTION
## Summary
- Read ADMIN_TOKEN from environment in admin page with localStorage fallback
- Validate admin token in meetings API and clarify missing/mismatched token errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b20aab68e8832a91ea7aaaa738609d