### PR TITLE
fix Next.js detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "film-club-monorepo",
+  "private": true,
+  "scripts": {
+    "dev": "npm --prefix filmclubapp run dev",
+    "build": "npm --prefix filmclubapp run build",
+    "start": "npm --prefix filmclubapp run start",
+    "lint": "npm --prefix filmclubapp run lint"
+  },
+  "dependencies": {
+    "next": "14.2.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add root `package.json` exposing Next.js dependency
- wire root scripts to run the Next.js app in `filmclubapp`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: interactive ESLint setup prompt)

------
https://chatgpt.com/codex/tasks/task_e_68b20c910ff8832a95f5faeb5190d1b1